### PR TITLE
Fix: Offset error in Disable Air mode

### DIFF
--- a/app/src/main/java/com/github/brokenithm/activity/MainActivity.kt
+++ b/app/src/main/java/com/github/brokenithm/activity/MainActivity.kt
@@ -873,7 +873,7 @@ class MainActivity : AppCompatActivity() {
             realBuf[46] = if (buffer.testBtn) 0x01 else 0x00
             realBuf[47] = if (buffer.serviceBtn) 0x01 else 0x00
         } else {
-            buffer.slider.copyInto(realBuf, 10)
+            buffer.slider.copyInto(realBuf, 8)
             realBuf[40] = if (buffer.testBtn) 0x01 else 0x00
             realBuf[41] = if (buffer.serviceBtn) 0x01 else 0x00
         }


### PR DESCRIPTION
The slider data should be placed at `realBuf + 8` instead of `realBuf + 10`
If the 32 bytes slider is placed at `realBuf + 10`, then it would occupy `buffer[40]` and `buffer[41]`, which are for test and service buttons